### PR TITLE
Initialize random seed in init function

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -52,6 +52,10 @@ type Token struct {
 	Key, Secret string
 }
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 // Authorize turns a request into valid oauth request by adding the
 // "Authorization" header
 func (c *Consumer) Authorize(req *http.Request, t *Token) {
@@ -81,7 +85,6 @@ const nonceLength = 20
 var alphanumeric = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 func nonce() string {
-	rand.Seed(time.Now().Unix())
 	nonce := make([]byte, nonceLength)
 	for i := 0; i < nonceLength; i++ {
 		nonce[i] = alphanumeric[rand.Intn(len(alphanumeric))]


### PR DESCRIPTION
Only initialize random seed once in the init function,
instead of initializing on each call to nonce().

While using this library for an oauth proxy service, I got weird issues with seemingly random 401 errors. When inspecting the requests it turned out this happened when to requests were sent to the same service at the same time, since they would both have the exact same nonce.

This pull request makes sure to set the rand seed once in an init function instead of each time nonce() is called. This way each request will have a unique nonce. Otherwise requests sent at the same time will get identical nonces.